### PR TITLE
Notify admins about a showcase site in need of a review

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -26,14 +26,14 @@ add_translation('en', array(
 	'admin:showcase:featured' => "Showcase",
 	'admin:showcase:pending' => "Pending",
 	'item:object:showcase' => "Elgg Site",
-	
+
 	'showcase:validate' => 'Validate',
 	'showcase:unvalidate' => 'Unvalidate',
 	'showcase:feature' => 'Feature',
 	'showcase:unfeature' => 'Unfeature',
 	'showcase:action:featured' => "Site has been featured",
 	'showcase:action:unfeatured' => "Site has been unfeatured",
-    
+
     // edit form
     'showcase:screenshot' => 'Screenshot',
     'showcase:screenshot:help' => 'You may upload up to 9 images.  Make sure the screenshots are of decent resolution - but <strong>no more than 2048px x 1536px</strong>',
@@ -41,7 +41,7 @@ add_translation('en', array(
 	'showcase:allow:comments' => "Allow Comments",
 	'showcase:add:another' => 'Add another',
 	'showcase:imagedelete:failed' => "There was an error deleting the screenshot",
-    
+
     // messages
     'showcase:error:permissions:edit' => "You do not have permission to edit this site!",
     'showcase:error:permissions:container' => "You do not have permission to add that site!",
@@ -61,17 +61,26 @@ add_translation('en', array(
 	'showcase:approval:message' => "Hello %s,
 The elgg site you have submitted has been approved by an administrator.
 You can view your site listing here: %s",
-	
+
 	// tabs
 	'showcase:tab:featured' => 'Showcase',
 	'showcase:tab:unvalidated' => 'Unvalidated',
-	
+
 	'showcase:title:featured' => "Showcase: the best of Elgg",
 	'showcase:title:owner' => "%s's Elgg Sites",
 	'showcase:title:friends' => "Friends Elgg Sites",
 	'showcase:title:unvalidated' => "Unvalidated Sites",
-	
+
 	'showcase:widget:title' => 'Elgg Sites',
 	'showcase:widget:description' => 'Display a list of your Elgg sites',
 	'showcase:widget:label:number' => 'Number to display',
+
+	// notifications
+	'showcase:notify:summary' => 'Pending showcase site: %s',
+	'showcase:notify:subject' => 'Pending showcase site: %s',
+	'showcase:notify:body' =>
+"
+There's a showcase site in need of a review:
+%s
+",
 ));

--- a/start.php
+++ b/start.php
@@ -4,15 +4,15 @@ elgg_register_event_handler('init', 'system', 'showcase_init');
 
 function showcase_init() {
 	elgg_extend_view('css/elgg', 'css/showcase');
-	
+
 	$js = elgg_get_simplecache_url('js', 'showcase/js');
 	elgg_register_simplecache_view('js/showcase/js');
 	elgg_register_js('showcase', $js);
-	
+
 	$masonry = elgg_get_simplecache_url('js', 'showcase/masonry');
 	elgg_register_simplecache_view('js/showcase/masonry');
 	elgg_register_js('showcase/masonry', $masonry);
-	
+
 	//general
 	elgg_register_entity_type("object", 'showcase');
 
@@ -30,18 +30,25 @@ function showcase_init() {
 	elgg_register_plugin_hook_handler('entity:url', 'object', 'showcase_url_handler');
 	elgg_register_plugin_hook_handler('register', 'menu:entity', 'showcase_entity_menu');
 	elgg_register_plugin_hook_handler('container_permissions_check', 'object', 'showcase_container_permissions');
-	
+	elgg_register_plugin_hook_handler('get', 'subscriptions', 'showcase_get_subscriptions');
+
 	elgg_register_event_handler('update', 'object', 'showcase_object_update');
 	elgg_register_event_handler('delete', 'object', 'showcase_object_delete');
 
+	// notifications
+	// review is needed whenever user edits the contents, so send notifications on both 'create' and 'update' event
+	elgg_register_notification_event('object', 'showcase', array('create', 'update'));
+	elgg_register_plugin_hook_handler('prepare', 'notification:create:object:showcase', 'showcase_prepare_notification');
+	elgg_register_plugin_hook_handler('prepare', 'notification:update:object:showcase', 'showcase_prepare_notification');
+
 	elgg_register_page_handler('showcase', 'showcase_page_handler');
-    
+
 	elgg_register_menu_item('site', ElggMenuItem::factory(array(
 		'name' => 'showcase',
 		'href' => '/showcase',
 		'text' => elgg_echo('showcase'),
 	)));
-	
+
 	elgg_register_widget_type('showcase', elgg_echo('showcase:widget:title'), elgg_echo('showcase:widget:description'), 'profile,dashboard');
 }
 
@@ -49,11 +56,11 @@ function showcase_page_handler($page) {
 	switch ($page[0]) {
 		case 'add':
 			gatekeeper();
-            
+
 			elgg_set_page_owner_guid($page[1]);
             elgg_push_breadcrumb(elgg_echo('showcase'), elgg_get_site_url() . 'showcase');
             elgg_push_breadcrumb(elgg_echo('showcase:add'));
-                
+
             $title = elgg_echo('showcase:add');
             $content = elgg_view_form('showcase/add', array('enctype' => 'multipart/form-data'));
             $layout = elgg_view_layout('content', array(
@@ -65,20 +72,20 @@ function showcase_page_handler($page) {
             echo elgg_view_page(elgg_echo('showcase'), $layout);
 			return true;
             break;
-            
+
         case 'edit':
             gatekeeper();
             $showcase = get_entity($page[1]);
-               
+
             if (!elgg_instanceof($showcase, 'object', 'showcase') || !$showcase->canEdit()) {
                forward('','404');
             }
-                
+
 			elgg_set_page_owner_guid($showcase->owner_guid);
             elgg_push_breadcrumb(elgg_echo('showcase'), elgg_get_site_url() . 'showcase');
             elgg_push_breadcrumb($showcase->title, $showcase->getURL());
             elgg_push_breadcrumb(elgg_echo('edit'));
-                
+
             $title = elgg_echo('showcase:edit');
             $content = elgg_view_form('showcase/edit', array('enctype' => 'multipart/form-data'), array('entity' => $showcase));
             $layout = elgg_view_layout('content', array(
@@ -93,15 +100,15 @@ function showcase_page_handler($page) {
         case 'view':
             // we're looking at a full view, or an error
             $showcase = get_entity($page[1]);
-             
+
             if (!elgg_instanceof($showcase, 'object', 'showcase')) {
                 forward('','404');
             }
-			
+
 			elgg_set_page_owner_guid($showcase->owner_guid);
 			elgg_push_breadcrumb(elgg_echo('showcase'), elgg_get_site_url() . 'showcase');
             elgg_push_breadcrumb($showcase->title, $showcase->getURL());
-                
+
             $title = $showcase->title;
 			$title_link = elgg_view('output/url', array(
 				'text' => $title,
@@ -109,11 +116,11 @@ function showcase_page_handler($page) {
 				'target' => '_blank'
 			));
             $content = elgg_view_entity($showcase, array('full_view' => true));
-			
+
 			if ($showcase->allow_comments) {
 				$content .= elgg_view_comments($showcase);
 			}
-			
+
             $layout = elgg_view_layout('content', array(
                 'title' => $title_link,
                 'content' => $content,
@@ -129,14 +136,14 @@ function showcase_page_handler($page) {
 			if (!elgg_instanceof($img, 'object', 'showcaseimg')) {
                 forward('','404');
             }
-			
+
 			if ($size == 'original') {
 				$size = '';
 			}
-			
+
 			$img->setFilename($img->file_prefix . $size . '.jpg');
 			$filename = $img->getFilenameOnFilestore();
-			
+
 			$filesize = @filesize($filename);
 			if ($filesize) {
 				header("Content-type: image/jpeg");
@@ -150,58 +157,58 @@ function showcase_page_handler($page) {
 			break;
 		case 'owner':
 			elgg_push_breadcrumb(elgg_echo('showcase'));
-			
+
 			$username = urldecode($page[1]);
 			$user = get_user_by_username($username);
 			if (!$user) {
 				return false;
 			}
 			elgg_set_page_owner_guid($user->guid);
-			
+
 			if (elgg_is_logged_in() && elgg_get_logged_in_user_guid() == $user->guid) {
                 elgg_register_title_button();
             }
-			
+
 			set_input('filter', 'owner');
 			set_input('owner_guid', $user->guid);
-            
+
 			if (include(dirname(__FILE__) . '/pages/showcase/list.php')) {
 				return true;
 			}
-            	
+
 			break;
-			
+
 		case 'friends':
 			elgg_push_breadcrumb(elgg_echo('showcase'));
-			
+
 			$username = urldecode($page[1]);
 			$user = get_user_by_username($username);
 			if (!$user) {
 				return false;
 			}
 			elgg_set_page_owner_guid($user->guid);
-			
+
 			set_input('filter', 'friends');
 			set_input('owner_guid', $user->guid);
-            
+
 			if (include(dirname(__FILE__) . '/pages/showcase/list.php')) {
 				return true;
 			}
 			break;
         default:
             elgg_push_breadcrumb(elgg_echo('showcase'));
-              
+
             if (elgg_is_logged_in()) {
                 elgg_register_title_button();
             }
-            
+
 			if (include(dirname(__FILE__) . '/pages/showcase/list.php')) {
 				return true;
 			}
-            
+
             break;
     }
-	
+
 	return false;
 }
 
@@ -229,15 +236,15 @@ function showcase_icon_url_handler($hook, $type, $return, $params) {
 	if (!elgg_instanceof($params['entity'], 'object', 'showcase')) {
 		return $return;
 	}
-	
+
 	// get first (oldest) image
 	$img = showcase_get_default_image($params['entity']);
-	
+
 	if ($img) {
 		$filename = md5($img->time_created);
 		return "showcase/icon/{$img->guid}/{$params['size']}/{$filename}.jpg";
 	}
-	
+
 	return $return;
 }
 
@@ -246,30 +253,30 @@ function showcase_entity_menu($hook, $type, $return, $params) {
 	if (!elgg_is_admin_logged_in()) {
 		return $return;
 	}
-	
+
 	if (!elgg_instanceof($params['entity'], 'object', 'showcase')) {
 		return $return;
 	}
-	
+
 	$text = elgg_echo('showcase:unvalidate');
 	if ($params['entity']->access_id == ACCESS_PRIVATE) {
 		$text = elgg_echo('showcase:validate');
 	}
 	$href = elgg_add_action_tokens_to_url('action/showcase/toggle_validation?guid='.$params['entity']->guid);
-	
+
 	$validate = new ElggMenuItem('validate', $text, $href);
 	$return[] = $validate;
-	
-	
+
+
 	$text = elgg_echo('showcase:feature');
 	if ($params['entity']->showcase_featured) {
 		$text = elgg_echo('showcase:unfeature');
 	}
 	$href = elgg_add_action_tokens_to_url('action/showcase/toggle_featured?guid='.$params['entity']->guid);
-	
+
 	$feature = new ElggMenuItem('feature', $text, $href);
 	$return[] = $feature;
-	
+
 	return $return;
 }
 
@@ -279,7 +286,7 @@ function showcase_object_update($event, $type, $object) {
 	if (!elgg_instanceof($object, 'object', 'showcase')) {
 		return;
 	}
-	
+
 	// update the access ID of attached screenshots
 	$images = elgg_get_entities_from_relationship(array(
 		'type' => 'object',
@@ -289,7 +296,7 @@ function showcase_object_update($event, $type, $object) {
 		'inverse_relationship' => true,
 		'limit' => false
 	));
-	
+
 	foreach ($images as $img) {
 		if ($img->access_id != $object->access_id) {
 			$img->access_id = $object->access_id;
@@ -310,12 +317,12 @@ function showcase_object_delete($event, $type, $object) {
 			'inverse_relationship' => true,
 			'limit' => false
 		));
-		
+
 		foreach ($images as $img) {
 			$img->delete();
 		}
 	}
-	
+
 	// if deleting an image, clean up the files
 	if (elgg_instanceof($object, 'object', 'showcaseimg')) {
 		// remove images
@@ -323,22 +330,22 @@ function showcase_object_delete($event, $type, $object) {
 		$filehandler->owner_guid = $object->owner_guid;
 		$filehandler->setFilename("{$object->file_prefix}.jpg");
 		$filehandler->delete();
-		
+
 		$filehandler->setFilename("{$object->file_prefix}master.jpg");
 		$filehandler->delete();
-		
+
 		$filehandler->setFilename("{$object->file_prefix}large.jpg");
 		$filehandler->delete();
-	
+
 		$filehandler->setFilename("{$object->file_prefix}medium.jpg");
 		$filehandler->delete();
-	
+
 		$filehandler->setFilename("{$object->file_prefix}small.jpg");
 		$filehandler->delete();
-	
+
 		$filehandler->setFilename("{$object->file_prefix}tiny.jpg");
 		$filehandler->delete();
-		
+
 		// now regenerate the default image size cache
 		$showcase = showcase_get_showcase_from_image($object);
 		$showcase->featured_image_size_cache = 0;
@@ -350,7 +357,7 @@ function showcase_container_permissions($hook, $type, $return, $params) {
 	if ($params['subtype'] != 'showcase') {
 		return $return;
 	}
-	
+
 	return true;
 }
 
@@ -359,22 +366,22 @@ function showcase_set_featured_dimensions($showcase) {
 	if (!elgg_instanceof($showcase, 'object', 'showcase')) {
 		return true;
 	}
-	
+
 	// we're caching the dimensions of the default image
 	// as they may take different sizes (not squared) and we want to know
 	// to set dimensions for masonry
 	$image = showcase_get_default_image($showcase);
-	
+
 	$sizes = array('tiny', 'small', 'medium', 'large', 'master');
-	
+
 	foreach ($sizes as $size) {
 		$image->setFilename($image->file_prefix . $size . '.jpg');
 		$imageinfo = getimagesize($image->getFilenameOnFilestore());
-		
+
 		$width = 'default_size_cache_' . $size . '_w';
 		$height = 'default_size_cache_' . $size . '_h';
-		
-		if ($imageinfo[0] && $imageinfo[1]) {			
+
+		if ($imageinfo[0] && $imageinfo[1]) {
 			$showcase->$width = $imageinfo[0];
 			$showcase->$height = $imageinfo[1];
 		}
@@ -383,7 +390,7 @@ function showcase_set_featured_dimensions($showcase) {
 			$showcase->$height = '';
 		}
 	}
-	
+
 	$showcase->featured_image_size_cache = 1;
 }
 
@@ -398,11 +405,11 @@ function showcase_get_default_image($showcase) {
 		'limit' => 1,
 		'order_by' => 'e.time_created ASC'
 	));
-	
+
 	if ($img[0]) {
 		return $img[0];
 	}
-	
+
 	return false;
 }
 
@@ -415,12 +422,82 @@ function showcase_get_showcase_from_image($image) {
 		'relationship_guid' => $image->guid,
 		'limit' => 1
 	));
-	
+
 	if ($showcase[0]) {
 		return $showcase[0];
 	}
-	
+
 	return false;
 }
 
+/**
+ * Prepare a notification message about a showcase site that needs to be reviewed
+ *
+ * @param string                          $hook         Hook name
+ * @param string                          $type         Hook type
+ * @param Elgg_Notifications_Notification $notification The notification to prepare
+ * @param array                           $params       Hook parameters
+ * @return Elgg_Notifications_Notification
+ */
+function showcase_prepare_notification($hook, $type, $notification, $params) {
+	$entity = $params['event']->getObject();
+	$language = $params['language'];
 
+	$notification->subject = elgg_echo('showcase:notify:subject', array($entity->title), $language);
+	$notification->body = elgg_echo('showcase:notify:body', array(
+		$entity->getURL()
+	), $language);
+	$notification->summary = elgg_echo('showcase:notify:summary', array($entity->title), $language);
+
+	return $notification;
+}
+
+/**
+ * Get two random admins to notify about a showcase site in need of a review
+ *
+ * @param string $hook          'get'
+ * @param string $type          'subscriptions'
+ * @param array  $subscriptions Array containing subscriptions in the form
+ *                                <user guid> => array(
+ *                                    'email',
+ *                                    'site',
+ *                                    'etc.',
+ *                                )
+ * @param array  $params        Hook parameters
+ * @return array $subscriptions Array containing the subscriptions
+ */
+function showcase_get_subscriptions($hook, $type, $subscriptions, $params) {
+	$event = $params['event'];
+
+	$object = $event->getObject();
+	if (!$object instanceof ElggShowcase) {
+		return $subscriptions;
+	}
+
+	$actor = $event->getActor();
+	if ($actor->isAdmin()) {
+		// No need to notify if the editing user was an admin
+		return $subscriptions;
+	}
+
+	// Get all admins
+	$admins = elgg_get_admins(array('limit' => 0));
+
+	// Randomize the admins array
+	shuffle($admins);
+
+	// Pick two of them
+	$admins = array_slice($admins, 0, 2);
+
+	// At this point $subscriptions contains all the showcase owner's friends
+	// who have subscribed to receive notifications. We don't want to inform
+	// them, so we need to reset the array.
+	$subscriptions = array();
+
+	// Tell subscriptions system to send an email notification to both admins
+	foreach ($admins as $admin) {
+		$subscriptions[$admin->guid] = array('email');
+	}
+
+	return $subscriptions;
+}


### PR DESCRIPTION
This will send an email notification to two randomly selected admins when a non-admin creates or updates a showcase site.

There's currently no way to prevent receiving these notifications. Does anyone object merging this without that possibility? I don't think the showcase items get created/updated often.
